### PR TITLE
Add gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+vendor/
+node_modules/
+npm-debug.log
+
+# Laravel 4 specific
+bootstrap/compiled.php
+app/storage/
+
+# Laravel 5 & Lumen specific
+public/storage
+public/hot
+storage/*.key
+.env.*.php
+.env.php
+.env
+Homestead.yaml
+Homestead.json
+
+# Rocketeer PHP task runner and deployment package. https://github.com/rocketeers/rocketeer
+.rocketeer/


### PR DESCRIPTION
É de extrema importância a existência de um arquivo .gitignore na raiz do projeto. Sem ele, vários arquivos, como os da pasta vendor, irão ficar hospedados no sistema de controle de versão, o que não é recomendado:

https://getcomposer.org/doc/faqs/should-i-commit-the-dependencies-in-my-vendor-directory.md

O recomendado é que após a adição do arquivo .gitignore na raiz do projeto, se exclua os arquivos que não devem estar hospedados (como os arquivos da pasta vendor) do branch remote.

O arquivo .gitignore presente nesse Pull Request, foi extraído [desse projeto](https://github.com/github/gitignore), que contém vários arquivos de exemplo, de acordo com a plataforma utilizada.